### PR TITLE
Updated keyservers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,11 @@
 class cassandra {
   apt::key { '0353B12C':
-    key_server => 'pgp.mit.edu',
+    key_server => 'pool.sks-keyservers.net',
     before     => Apt::Source['apache-cassandra']
   }
 
   apt::key { '2B5C1B00':
-    key_server => 'pgp.mit.edu',
+    key_server => 'pool.sks-keyservers.net',
     before     => Apt::Source['apache-cassandra']
   }
 


### PR DESCRIPTION
'pool.sks-keyservers.net' is reputed to be more decentralized and reliable. We have experienced at least one instance of the pgp.mit.edu server being unreliable, causing a provisioning operation to fail.